### PR TITLE
Fix yoshi-deluxe imports and recovery traits

### DIFF
--- a/yoshi-deluxe/Cargo.toml
+++ b/yoshi-deluxe/Cargo.toml
@@ -32,7 +32,7 @@ syn = { version = "2.0.101", features = [
     "extra-traits",
 ] }
 quote = "1.0.40"
-proc-macro2 = "1.0.95"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
 
 # HTTP client for docs scraping
 reqwest = { version = "0.12.19", features = [

--- a/yoshi-deluxe/src/lib.rs
+++ b/yoshi-deluxe/src/lib.rs
@@ -80,18 +80,20 @@ pub mod types;
 // Re-export core types and functionality
 pub use ast::{ASTAnalysisEngine, ASTContext, NodeInfo, NodeType, SurroundingContext};
 pub use codegen::CodeGenerationEngine;
-pub use types::{CorrectionProposal, CorrectionStrategy, SafetyLevel};
 pub use constants::*;
 pub use diagnostics::CompilerDiagnosticProcessor;
-pub use docs::{DocsScrapingEngine, MethodSuggestion};
+pub use docs::DocsScrapingEngine;
 pub use errors::{AutoCorrectionError, Result};
 pub use metrics::{SystemMetrics, SystemMetricsSnapshot};
-pub use system::{AutoCorrectionSystem, SystemConfig};
-pub use types::*;
+pub use system::AutoCorrectionSystem;
+pub use types::{
+    CorrectionProposal, CorrectionStrategy, MethodSuggestion, SafetyLevel, SystemConfig,
+};
 
 // Re-export yoshi-std types for convenience
+use std::collections::HashMap;
 pub use yoshi_std::{Hatch, Result as YoshiResult, Yoshi, YoshiKind};
-use yoshi_std::LayText;
+use yoshi_std::{Hatchable, LayText};
 
 //--------------------------------------------------------------------------------------------------
 // Public API Convenience Functions
@@ -213,10 +215,10 @@ pub struct SystemCapabilities {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use yoshi_std::LayText;
     use std::path::PathBuf;
     use tempfile::TempDir;
     use tokio::fs;
+    use yoshi_std::LayText;
 
     async fn create_test_project() -> Result<TempDir> {
         let temp_dir = tempfile::tempdir()
@@ -586,8 +588,6 @@ pub mod benchmarks {
 //==================================================================================================
 // Module Implementation Files
 //==================================================================================================
-
-
 
 //--------------------------------------------------------------------------------------------------
 // System Health and Monitoring


### PR DESCRIPTION
## Summary
- update proc-macro2 with span-locations feature
- cleanup lib reexports and import HashMap, Hatchable
- implement `From<syn::Error>` and `From<reqwest::Error>` for `Yoshi`
- fix recovery helpers to accept `FnMut`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p yoshi-deluxe --all-targets --jobs=1 -- -D warnings` *(fails: jobs may not be 0)*
- `cargo test -p yoshi-deluxe --jobs=1` *(fails to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6846637ea7a8832ba2fd60d29b3391dd